### PR TITLE
Configure /proc mount for system metrics plugin on DaemonSet

### DIFF
--- a/kube-ao-daemonset.yaml
+++ b/kube-ao-daemonset.yaml
@@ -24,6 +24,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: HOST_PROC
+            value: "/host/proc"
         volumeMounts:
           - name: docker-sock
             mountPath: /var/run/docker.sock


### PR DESCRIPTION
Setting HOST_PROC to /host/proc into the container tells our system metrics plugin (aosystem, which relies on https://github.com/shirou/gopsutil/) to report host metrics from the host, rather than from the container the DaemonSet agent is running in.