### PR TITLE
Enable MySQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,7 @@ The following environment parameters are available:
  APPOPTICS_ENABLE_KUBERNETES | Set this to `true` to enable the Kubernetes plugin.
  APPOPTICS_DISABLE_HOSTAGENT | Set this to `true` to disable the Host Agent system metrics collection.
  APPOPTICS_ENABLE_ZOOKEEPER  | Set this to `true` to enable the Zookeeper plugin.
- APPOPTICS_ENABLE_MYSQL      | Set this to `true` to enable the MySQL plugin. If enabled the following are required to be set as well: MYSQL_USER, MYSQL_PASS, MYSQL_HOST & MYSQL_PORT
- MYSQL_USER                  | Set this to your MySQL user.
- MYSQL_PASS                  | Set this to your MySQL password.
- MYSQL_HOST                  | Set this to your MySQL hostname or IP address.
- MYSQL_PORT                  | Set this to your MySQL port.
+ APPOPTICS_ENABLE_MYSQL      | Set this to `true` to enable the MySQL plugin. If enabled the following ENV vars are required to be set as well: MYSQL_USER, MYSQL_PASS, MYSQL_HOST & MYSQL_PORT
 
 ## Dashboard
 Successful deployments will report metrics in the AppOptics Kubernetes Dashboard.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ The following environment parameters are available:
  APPOPTICS_ENABLE_KUBERNETES | Set this to `true` to enable the Kubernetes plugin.
  APPOPTICS_DISABLE_HOSTAGENT | Set this to `true` to disable the Host Agent system metrics collection.
  APPOPTICS_ENABLE_ZOOKEEPER  | Set this to `true` to enable the Zookeeper plugin.
+ APPOPTICS_ENABLE_MYSQL      | Set this to `true` to enable the MySQL plugin. If enabled the following are required to be set as well: MYSQL_USER, MYSQL_PASS, MYSQL_HOST & MYSQL_PORT
+ MYSQL_USER                  | Set this to your MySQL user.
+ MYSQL_PASS                  | Set this to your MySQL password.
+ MYSQL_HOST                  | Set this to your MySQL hostname or IP address.
+ MYSQL_PORT                  | Set this to your MySQL port.
 
 ## Dashboard
 Successful deployments will report metrics in the AppOptics Kubernetes Dashboard.

--- a/conf/appoptics-init.sh
+++ b/conf/appoptics-init.sh
@@ -50,6 +50,11 @@ if [ "$APPOPTICS_ENABLE_ZOOKEEPER" = "true" ]; then
     mv /opt/appoptics/etc/plugins.d/zookeeper.yaml.example /opt/appoptics/etc/plugins.d/zookeeper.yaml
 fi
 
+if [ "$APPOPTICS_ENABLE_MYSQL" = "true" ]; then
+    mv /opt/appoptics/etc/plugins.d/mysql.yaml.example /opt/appoptics/etc/plugins.d/mysql.yaml
+    sed -i -e "s/root:admin\@tcp(mysql:3306)/$MYSQL_USER:$MYSQL_PASS\@tcp($MYSQL_HOST:$MYSQL_PORT)/" /opt/appoptics/etc/plugins.d/mysql.yaml
+fi
+
 if [ "$APPOPTICS_DISABLE_HOSTAGENT" = "true" ]; then
     rm /opt/appoptics/autoload/snap-plugin-collector-aosystem
     rm /opt/appoptics/autoload/task-aosystem-warmup.yaml


### PR DESCRIPTION
1. Create switch for $APPOPTICS_ENABLE_MYSQL
2.  rename mysql.yaml.example to mysql.yaml
3. sed replace default mysql connection string values with the following environment variables:
- MYSQL_USER
- MYSQL_PASS
- MYSQL_HOST
- MYSQL_PORT