### PR TITLE
Sed replace the mysql configuration conditionals

### DIFF
--- a/conf/appoptics-init.sh
+++ b/conf/appoptics-init.sh
@@ -52,7 +52,7 @@ fi
 
 if [ "$APPOPTICS_ENABLE_MYSQL" = "true" ]; then
     mv /opt/appoptics/etc/plugins.d/mysql.yaml.example /opt/appoptics/etc/plugins.d/mysql.yaml
-    if [[ -n ${MYSQL_USER} && -n ${MYSQL_PASS} && -n ${MYSQL_HOST} && -n ${MYSQL_PORT} ]]; then
+    if [[ -n ${MYSQL_USER} && -n ${MYSQL_HOST} && -n ${MYSQL_PORT} ]]; then
         sed -i -e "s/root:admin\@tcp(mysql:3306)/$MYSQL_USER:$MYSQL_PASS\@tcp($MYSQL_HOST:$MYSQL_PORT)/" /opt/appoptics/etc/plugins.d/mysql.yaml
     fi
 fi

--- a/conf/appoptics-init.sh
+++ b/conf/appoptics-init.sh
@@ -52,7 +52,9 @@ fi
 
 if [ "$APPOPTICS_ENABLE_MYSQL" = "true" ]; then
     mv /opt/appoptics/etc/plugins.d/mysql.yaml.example /opt/appoptics/etc/plugins.d/mysql.yaml
-    sed -i -e "s/root:admin\@tcp(mysql:3306)/$MYSQL_USER:$MYSQL_PASS\@tcp($MYSQL_HOST:$MYSQL_PORT)/" /opt/appoptics/etc/plugins.d/mysql.yaml
+    if [[ -n ${MYSQL_USER} && -n ${MYSQL_PASS} && -n ${MYSQL_HOST} && -n ${MYSQL_PORT} ]]; then
+        sed -i -e "s/root:admin\@tcp(mysql:3306)/$MYSQL_USER:$MYSQL_PASS\@tcp($MYSQL_HOST:$MYSQL_PORT)/" /opt/appoptics/etc/plugins.d/mysql.yaml
+    fi
 fi
 
 if [ "$APPOPTICS_DISABLE_HOSTAGENT" = "true" ]; then


### PR DESCRIPTION
**Files Modified**
appoptics-init.sh 

**Change**
Only sed replace variables if the MYSQL_HOST, MYSQL_PORT & MYSQL_USER are present. MYSQL_PASS was intentionally left out to support blank passwords.

If theses variables aren't passed and APPOPTICS_ENABLE_MYSQL is true, appoptics agent will attempt to use the default connection string.

