### PR TITLE
Set hostNetwork to true, add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ kubectl apply -f appoptics-agent-daemonset.yaml
 
 Enable the Docker plugin in the AppOptics UI and you should start seeing data trickle in.
 
+### Host Network
+
+By default, Kubernetes pods use a namespaced network overlay for all traffic to and from the pod. When network overlay issues occur, this can cause the AppOptics agent to stop reporting. To solve this, the AppOptics Deployment and DaemonSet agent pods run on the host network. To disable this and use the network overlay stack, change `hostNetwork` to `false` in `appoptics-agent-daemonset.yaml` and `appoptics-agent-deployment.yaml`.
+
 ### Sidecar
 
 If you wanted to run this on Kubernetes as a sidecar for monitoring specific services, you can follow the instructions below which use Zookeeper as an example.
@@ -60,16 +64,16 @@ Add a second container to your deployment YAML underneath `spec.template.spec.co
 
 The following environment parameters are available:
 
- Parameter                   | Description
------------------------------|---------------------
- APPOPTICS_TOKEN             | Your AppOptics token. This parameter is required.
- LOG_LEVEL                   | Expected value: DEBUG, INFO, WARN, ERROR or FATAL. Default value is WARN.
- APPOPTICS_HOSTNAME          | This value overrides the hostname tagged for default host metrics. The DaemonSet uses this to override with Node name.
- APPOPTICS_ENABLE_DOCKER     | Set this to `true` to enable the Docker plugin.
- APPOPTICS_ENABLE_KUBERNETES | Set this to `true` to enable the Kubernetes plugin.
- APPOPTICS_DISABLE_HOSTAGENT | Set this to `true` to disable the Host Agent system metrics collection.
- APPOPTICS_ENABLE_ZOOKEEPER  | Set this to `true` to enable the Zookeeper plugin.
- APPOPTICS_ENABLE_MYSQL      | Set this to `true` to enable the MySQL plugin. If enabled the following ENV vars are required to be set as well: MYSQL_USER, MYSQL_PASS, MYSQL_HOST & MYSQL_PORT
+ | Parameter                   | Description                                                                                                                                                      |
+ | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+ | APPOPTICS_TOKEN             | Your AppOptics token. This parameter is required.                                                                                                                |
+ | LOG_LEVEL                   | Expected value: DEBUG, INFO, WARN, ERROR or FATAL. Default value is WARN.                                                                                        |
+ | APPOPTICS_HOSTNAME          | This value overrides the hostname tagged for default host metrics. The DaemonSet uses this to override with Node name.                                           |
+ | APPOPTICS_ENABLE_DOCKER     | Set this to `true` to enable the Docker plugin.                                                                                                                  |
+ | APPOPTICS_ENABLE_KUBERNETES | Set this to `true` to enable the Kubernetes plugin.                                                                                                              |
+ | APPOPTICS_DISABLE_HOSTAGENT | Set this to `true` to disable the Host Agent system metrics collection.                                                                                          |
+ | APPOPTICS_ENABLE_ZOOKEEPER  | Set this to `true` to enable the Zookeeper plugin.                                                                                                               |
+ | APPOPTICS_ENABLE_MYSQL      | Set this to `true` to enable the MySQL plugin. If enabled the following ENV vars are required to be set as well: MYSQL_USER, MYSQL_PASS, MYSQL_HOST & MYSQL_PORT |
 
 ## Dashboard
 Successful deployments will report metrics in the AppOptics Kubernetes Dashboard.

--- a/appoptics-agent-daemonset.yaml
+++ b/appoptics-agent-daemonset.yaml
@@ -15,6 +15,7 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      hostNetwork: true
       containers:
       - name: appoptics-agent-ds
         image: 'appoptics/appoptics-agent-docker:v0.2'

--- a/appoptics-agent-deployment.yaml
+++ b/appoptics-agent-deployment.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       serviceAccountName: appoptics-agent-serviceaccount
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: appoptics-agent-k8s
           image: 'appoptics/appoptics-agent-docker:v0.2'

--- a/appoptics-agent-deployment.yaml
+++ b/appoptics-agent-deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: appoptics-agent-k8s
     spec:
       serviceAccountName: appoptics-agent-serviceaccount
+      hostNetwork: true
       containers:
         - name: appoptics-agent-k8s
           image: 'appoptics/appoptics-agent-docker:v0.2'


### PR DESCRIPTION
This pull requests sets the AppOptics DaemonSet to use host networking instead of the overlay networking. If there are issues with the overlay network (say, Calico or Flannel), this enables the AppOptics agent to continue reporting instead of being down.

This also sets a DNS policy on the deployment manifest so that DNS resolution for the Kubernetes API server still works on the host network.

It'd be nice if, separately, we could still somehow get overlay network stats (maybe via an agent level change) as well but I believe when people (speaking for myself here) install the agent, what they expect are host network traffic stats by default. They could theoretically still get both by installing a second DaemonSet with hostNetwork set to false. I've also added this to the README for documentation.